### PR TITLE
Add `signals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ if (db.supports.additionalMethods.foo) {
 
 For future extensibility, the properties of `additionalMethods` should be taken as truthy rather than strictly typed booleans. We may add additional metadata (see [#1](https://github.com/Level/supports/issues/1)).
 
+### `signals` (object)
+
+Which methods or method groups take a `signal` option? At the time of writing there is only one method group: `iterators`. This includes `db.iterator()`, `db.keys()` and `db.values()`. For example:
+
+```js
+if (db.supports.signals.iterators) {
+  const ac = new AbortController()
+  const iterator = db.keys({ signal: ac.signal })
+
+  ac.abort()
+}
+```
+
 ## Install
 
 With [npm](https://npmjs.org) do:

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,4 +103,20 @@ export interface IManifest {
    * ```
    */
   additionalMethods: Record<string, boolean>
+
+  /**
+   * Which methods or method groups take a `signal` option? At the time of writing there
+   * is only one method group: `iterators`. This includes `db.iterator()`, `db.keys()` and
+   * `db.values()`. For example:
+   *
+   * ```js
+   * if (db.supports.signals.iterators) {
+   *   const ac = new AbortController()
+   *   const iterator = db.keys({ signal: ac.signal })
+   *
+   *   ac.abort()
+   * }
+   * ```
+   */
+  signals: Record<string, boolean>
 }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ exports.supports = function supports (...manifests) {
     streams: manifest.streams || false,
     encodings: Object.assign({}, manifest.encodings),
     events: Object.assign({}, manifest.events),
-    additionalMethods: Object.assign({}, manifest.additionalMethods)
+    additionalMethods: Object.assign({}, manifest.additionalMethods),
+    signals: Object.assign({}, manifest.signals)
   })
 }

--- a/test/shape.js
+++ b/test/shape.js
@@ -5,6 +5,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty
 module.exports = function shape (t, manifest) {
   t.ok(isObject(manifest), 'manifest is object')
   t.ok(isObject(manifest.additionalMethods), 'additionalMethods is object')
+  t.ok(isObject(manifest.signals), 'signals is object')
 
   for (const k in manifest) {
     if (!hasOwnProperty.call(manifest, k)) continue


### PR DESCRIPTION
Mainly for tests. This way I can add support of signals to `classic-level` and add tests for it in `abstract-level` that do:

```js
if (db.supports.signals?.iterators) {
  test('abort', function (t) {
    // ..
  })
}
```